### PR TITLE
Update to latest version nix-blockchain-development and nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1661362553,
-        "narHash": "sha256-8SAbNuOXLvStkmge5mkjo3gPxhj/5jpEDP48IJ9tc2s=",
+        "lastModified": 1665595278,
+        "narHash": "sha256-KbzhDd4cZEaPPNJ2q35ItrI+gfes+avUSuNG58b/R0o=",
         "owner": "metacraft-labs",
         "repo": "nix-blockchain-development",
-        "rev": "4c2051c7922e14dbb1f1074105e8a39a6de8a685",
+        "rev": "72e38665ff973de1021fcb4ec9add7c590f622f6",
         "type": "github"
       },
       "original": {
@@ -36,16 +36,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661262176,
-        "narHash": "sha256-42FXNd2B0QECaULG0Vx+oYzQ9euKcmlg2gmX2D+HbKI=",
+        "lastModified": 1665449268,
+        "narHash": "sha256-cw4xrQIAZUyJGj58Dp5VLICI0rscd+uap83afiFzlcA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b9fd420fa535fd254c6f1f26df770b32a9dc98b4",
+        "rev": "285e77efe87df64105ec14b204de6636fb0a7a27",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,15 @@
       inherit self nixpkgs;
       name = "DendrETH";
       shell = ./shell.nix;
+      config = {
+        permittedInsecurePackages = [
+          # wasm3 is insecure if used to execute untrusted third-party code
+          # however, since we're using it for development, these problems do not
+          # affect us.
+          # Marked as insecure: https://github.com/NixOS/nixpkgs/pull/192915
+          "wasm3-0.5.0"
+        ];
+      };
       preOverlays = [mcl-blockchain.overlays.default (import ./libs/nix/overlay.nix)];
     };
 }

--- a/libs/nix/nim-wasm/default.nix
+++ b/libs/nix/nim-wasm/default.nix
@@ -3,6 +3,7 @@
   writeShellApplication,
   llvm,
   nim,
+  emscripten-enriched-cache,
 }: let
   nimcfg = writeTextFile {
     name = "nim-cfg";
@@ -74,10 +75,6 @@
         --passC:"-Werror"
         --passC:"-Wall"
 
-        # --passL:"--target=wasm32-unknown-unknown-wasm"
-        # --passL:"-nostdlib"
-        # --passL:"-Wl,--no-entry,-L/nix/store/cxgpscy3p231hii96c311haz3lqcf47g-emscripten-3.0.0/share/emscripten/cache/sysroot/lib/wasm32-emscripten,-lGL,-lal,-lstubs,-lc,-lcompiler_rt,-lc++-noexcept,-lc++abi-noexcept,-ldlmalloc,-lstandalonewasm-memgrow,-lc_rt-optz,-lsockets,--import-undefined,-z,stack-size=5242880,--initial-memory=16777216,--max-memory=2147483648,--global-base=1024"
-
         # General LLD options: https://man.archlinux.org/man/extra/lld/ld.lld.1.en
         --passL:"--target=wasm32-unknown-unknown-wasm"
         --passL:"-nostdlib"
@@ -86,7 +83,7 @@
         --passL:"-Wl,-z,stack-size=5242880"
 
         # Link libraries
-        --passL:"-Wl,-L/nix/store/cxgpscy3p231hii96c311haz3lqcf47g-emscripten-3.0.0/share/emscripten/cache/sysroot/lib/wasm32-emscripten"
+        --passL:"-Wl,-L${emscripten-enriched-cache}/share/emscripten/cache/sysroot/lib/wasm32-emscripten"
         --passL:"-Wl,-lstubs,-lc"
         --passL:"-Wl,-ldlmalloc"
         --passL:"-Wl,-lc_rt-optz"

--- a/libs/nix/nim-wasm/default.nix
+++ b/libs/nix/nim-wasm/default.nix
@@ -86,7 +86,6 @@
         --passL:"-Wl,-L${emscripten-enriched-cache}/share/emscripten/cache/sysroot/lib/wasm32-emscripten"
         --passL:"-Wl,-lstubs,-lc"
         --passL:"-Wl,-ldlmalloc"
-        --passL:"-Wl,-lc_rt-optz"
 
         # Wasm specific LLD options: https://lld.llvm.org/WebAssembly.html
         --passL:"-Wl,--export-dynamic"

--- a/libs/typescript/ts-utils/wasm-utils.ts
+++ b/libs/typescript/ts-utils/wasm-utils.ts
@@ -137,6 +137,7 @@ export async function loadWasm<Exports extends WebAssembly.Exports>({
           );
 
           var replacement = emscripten_realloc_buffer(newSize, memory);
+          HEAPU8 = new Uint8Array(memory.buffer);
           if (replacement) {
             return true;
           }


### PR DESCRIPTION
Also allow [`wasm3`](https://github.com/wasm3/wasm3) package, which has been [marked as insecure](https://github.com/NixOS/nixpkgs/pull/192915) in Nixpkgs since Google OSS Fuzz had [found](https://github.com/google/oss-fuzz-vulns/tree/main/vulns/wasm3) vulnerabilities. Reasoning: `wasm3` is useful for local development and it is not for executing untrusted third-party code.