### PR TITLE
Add additional networks to hardhat

### DIFF
--- a/beacon-light-client/solidity/hardhat.config.ts
+++ b/beacon-light-client/solidity/hardhat.config.ts
@@ -93,6 +93,8 @@ export default {
       accounts: [optionalConf.USER_PRIVATE_KEY],
     },
     //WIP, faucet claims i'm a robot, and won't give me BNB
+    // despite this I still ended up getting tokens from the faucet, howeever am now getting "Invalid JSON-RPC responsee received"
+    // this will require further research
     "binance-smart-contract": {
       url: `https://data-seed-prebsc-1-s1.binance.org:8545`,
       accounts: [optionalConf.USER_PRIVATE_KEY],
@@ -102,6 +104,24 @@ export default {
       url: `https://eth-rpc-api-testnet.thetatoken.org/rpc`,
       accounts: [optionalConf.USER_PRIVATE_KEY],
     },
+    "polygon": {
+      url: `https://matic-mumbai.chainstacklabs.com/`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    "ethereum-classic": {
+      url: `https://www.ethercluster.com/mordor`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    //WIP, faucet is broken, "1010: Invalid Transaction: Transaction has a bad signature"
+    "polkadot": {
+      url:`rpc.pinknode.io/westend`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    //WIP, can't get private key from testneet wallet
+    "near": {
+      url:`https://rpc.testnet.near.org`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    }
   },
   mocha: {
     timeout: 100000000,

--- a/beacon-light-client/solidity/hardhat.config.ts
+++ b/beacon-light-client/solidity/hardhat.config.ts
@@ -18,6 +18,7 @@ const mandatoryConf = {
     '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
   INFURA_API_KEY: process.env.INFURA_API_KEY,
   ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY,
+  NODE_ID: process.env.NODE_ID || '0',
 };
 
 for (const envVar of Object.keys(mandatoryConf)) {
@@ -60,6 +61,45 @@ export default {
     },
     mainnet: {
       url: `https://goerli.infura.io/v3/${mandatoryConf.INFURA_API_KEY}`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    "fantom-test": {
+      url: "https://rpc.testnet.fantom.network",
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+      chainId: 4002,
+      live: false,
+      saveDeployments: true,
+      gasMultiplier: 2,
+    },
+    "avalanche-mainnet": {
+      url: `https://avalanche-mainnet.infura.io/v3/${mandatoryConf.INFURA_API_KEY}`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    "avalanche-fuji": {
+      url: `https://avalanche-fuji.infura.io/v3/${mandatoryConf.INFURA_API_KEY}`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    "celo-mainnet": {
+      url: `https://celo-mainnet.infura.io/v3/${mandatoryConf.INFURA_API_KEY}`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    "celo-alfajores": {
+      url: `https://celo-alfajores.infura.io/v3/${mandatoryConf.INFURA_API_KEY}`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    //WIP, getting error "could not detect network"
+    hedera: {
+      url: `https://${mandatoryConf.NODE_ID}.testnet.hedera.com`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    //WIP, faucet claims i'm a robot, and won't give me BNB
+    "binance-smart-contract": {
+      url: `https://data-seed-prebsc-1-s1.binance.org:8545`,
+      accounts: [optionalConf.USER_PRIVATE_KEY],
+    },
+    //WIP, no faucet with which to gain TFUEL, theta RPC returns an error: -32000: Failed to get the account (the address has no Theta nor TFuel)
+    "theta": {
+      url: `https://eth-rpc-api-testnet.thetatoken.org/rpc`,
       accounts: [optionalConf.USER_PRIVATE_KEY],
     },
   },

--- a/beacon-light-client/solidity/tasks/deploy.ts
+++ b/beacon-light-client/solidity/tasks/deploy.ts
@@ -1,8 +1,8 @@
 import { task } from 'hardhat/config';
 import { getConstructorArgs } from './utils';
 
-task('deploy', 'Deploy the beacon light client contract').setAction(
-  async (_, { run, ethers, network }) => {
+task('deploy', 'Deploy the beacon light client contract').addParam("targetNetwork", "Network to use when updating the light client.", "mainnet").setAction(
+  async (taskArgs, { run, ethers, network }) => {
     await run('compile');
     const [deployer] = await ethers.getSigners();
 
@@ -11,7 +11,7 @@ task('deploy', 'Deploy the beacon light client contract').setAction(
 
     const beaconLightClient = await (
       await ethers.getContractFactory('BeaconLightClient')
-    ).deploy(...getConstructorArgs(network.name));
+    ).deploy(...getConstructorArgs(taskArgs.targetNetwork));
 
     console.log('>>> Waiting for BeaconLightClient deployment...');
 


### PR DESCRIPTION
Progress:
- avalanche, fantom and celo are properly working.
- fantom however requires the mnemotic as a USER_PRIVATE_KEY
- hedera, binance-smart-contract and theta have beeen added, however due to issues explained in comments in hardhat.config.ts, they do not currently work.
- changes have been made to deploy.ts, to allow specifying the network (mainnet or prater), seperately. It defaults to mainnet.