### PR TITLE
Hstaykov/refactor loops

### DIFF
--- a/vendor/zkllvm-metacraft-circuits/docker/Dockerfile
+++ b/vendor/zkllvm-metacraft-circuits/docker/Dockerfile
@@ -4,5 +4,6 @@ RUN echo 'deb [trusted=yes]  http://deb.nil.foundation/ubuntu/ all main' >>/etc/
 RUN apt update && apt -y upgrade
 RUN apt install -y zkllvm proof-producer
 RUN apt install -y vim libyaml-cpp-dev cmake clang-format libboost-all-dev
+RUN apt update && apt -y upgrade
 
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]

--- a/vendor/zkllvm-metacraft-circuits/docs/compute_shuffled_index.md
+++ b/vendor/zkllvm-metacraft-circuits/docs/compute_shuffled_index.md
@@ -1,0 +1,18 @@
+# Compute shuffled index documentation.
+
+### *Implementation*
+   The implementation code of the circuit is under "DendrETH/vendor/zkllvm-metacraft-circuits/src/circuits_impl/compute_shuffled_index_impl.h". 
+   This code is used in both the compilation as circuit and as executable.
+
+### *Circuit build*
+   In order to build as circuit, we need an entry point marked with the `[[circuit]]` directive. This is done through a wrapper 
+   that uses the implementation code and resides in "DendrETH/vendor/zkllvm-metacraft-circuits/src/circuits/compute_shuffled_index.cpp". Since currently the Crypto3
+   library does not implement computation of sha256 on a byte buffer, we use a header only library for the sha256 computations, which has 
+   negative performance consequences.
+
+### *Executable build + tests*
+   The implementation code of the circuit is compiled as executable and tested against the input data from 
+   https://github.com/ethereum/consensus-spec-tests.git. The tests reside in "DendrETH/vendor/zkllvm-metacraft-circuits/src/tests/compute_shuffled_index_test/".
+   For convenience, we have a script that performs all necessary steps to run the test -> "DendrETH/vendor/zkllvm-metacraft-circuits/scripts/compile_and_run_tests.sh", which by default runs all tests. We can pass as argument to this script "compute_shuffled_index_test" which will only run the relevant tests. For example, run the script from the main project directory "DendrETH/vendor/zkllvm-metacraft-circuits" as follows:
+   `./scripts/compile_and_run_tests.sh compute_shuffled_index_test`
+   It is required that docker is installed on the machine that will run the tests.

--- a/vendor/zkllvm-metacraft-circuits/docs/verify_attestation_data_and_proof_finality.md
+++ b/vendor/zkllvm-metacraft-circuits/docs/verify_attestation_data_and_proof_finality.md
@@ -1,0 +1,16 @@
+# Verify attestation data and proof finality documentation.
+
+### *Implementation*
+   The implementation code of the circuit is under "DendrETH/vendor/zkllvm-metacraft-circuits/src/circuits_impl/verify_attestation_data_impl.h". 
+   This code is used in both the compilation as circuit and as executable.
+
+### *Circuit build*
+   In order to build as circuit, we need an entry point marked with the `[[circuit]]` directive. This is done through a wrapper 
+   that uses the implementation code and resides in "DendrETH/vendor/zkllvm-metacraft-circuits/src/circuits/verify_attestation_data.cpp". This file also contains the proof_finality logic.
+
+### *Executable build + tests*
+   The implementation code of the circuit is compiled as executable and tested against input data extracted from 
+   an Ethereum node. The tests reside in "DendrETH/vendor/zkllvm-metacraft-circuits/src/tests/verify_attestation_data_test".
+   For convenience, we have a script that performs all necessary steps to run the test -> "DendrETH/vendor/zkllvm-metacraft-circuits/scripts/compile_and_run_tests.sh", which by default runs all tests. We can pass as argument to this script "verify_attestation_data_test" which will only run the relevant tests. For example, run the script from the main project directory "DendrETH/vendor/zkllvm-metacraft-circuits" as follows:
+   `./scripts/compile_and_run_tests.sh verify_attestation_data_test`
+   It is required that docker is installed on the machine that will run the tests.

--- a/vendor/zkllvm-metacraft-circuits/docs/weigh_justification_and_finalization.md
+++ b/vendor/zkllvm-metacraft-circuits/docs/weigh_justification_and_finalization.md
@@ -1,0 +1,15 @@
+# Weigh justification and finalization documentation.
+
+### *Implementation*
+   The implementation code of the circuit is under "DendrETH/vendor/zkllvm-metacraft-circuits/src/circuits_impl/weigh_justification_and_finalization_impl.h". 
+   This code is used in both the compilation as circuit and as executable.
+
+### *Circuit build*
+   In order to build as circuit, we need an entry point marked with the `[[circuit]]` directive. This is done through a wrapper 
+   that uses the implementation code and resides in "DendrETH/vendor/zkllvm-metacraft-circuits/src/circuits/weigh_justification_and_finalization.cpp".
+
+### *Executable build + tests*
+   The implementation code of the circuit is compiled as executable and tested against input data extracted from an Ethereum node. The tests reside in "DendrETH/vendor/zkllvm-metacraft-circuits/src/tests/weigh_justification_and_finalization_test".
+   For convenience, we have a script that performs all necessary steps to run the test -> "DendrETH/vendor/zkllvm-metacraft-circuits/scripts/compile_and_run_tests.sh", which by default runs all tests. We can pass as argument to this script "weigh_justification_and_finalization_test" which will only run the relevant tests. For example, run the script from the main project directory "DendrETH/vendor/zkllvm-metacraft-circuits" as follows:
+   `./scripts/compile_and_run_tests.sh weigh_justification_and_finalization_test`
+   It is required that docker is installed on the machine that will run the tests.

--- a/vendor/zkllvm-metacraft-circuits/scripts/compile_and_run_tests.sh
+++ b/vendor/zkllvm-metacraft-circuits/scripts/compile_and_run_tests.sh
@@ -9,9 +9,19 @@ echo "CURRENT_DIR = " $CURRENT_DIR
 cd $SCRIPT_DIR/../docker && docker build -t zcli:latest -f Dockerfile_zcli . \
                          && docker run -v $SCRIPT_DIR/../../:/DendrETH --user $(id -u ${USER}):$(id -g ${USER}) zcli:latest
 
-if [ ! -d $SCRIPT_DIR/../src/tests/verify_attestation_data_test/finalizer-data ]
-then 
-    git clone git@github.com:metacraft-labs/finalizer-data.git $SCRIPT_DIR/../src/tests/verify_attestation_data_test/finalizer-data
+
+FINALIZER_DATA_TEST_DIR=$SCRIPT_DIR/../src/tests/verify_attestation_data_test/finalizer-data
+
+if [ ! -d $FINALIZER_DATA_TEST_DIR ]
+then
+    git clone git@github.com:metacraft-labs/finalizer-data.git $FINALIZER_DATA_TEST_DIR
+fi
+
+CONSENSUS_SPEC_TEST_DATA_DIR=$SCRIPT_DIR/../../consensus-spec-tests
+
+if [ ! -d $CONSENSUS_SPEC_TEST_DATA_DIR ]
+then
+    git clone git@github.com:ethereum/consensus-spec-tests.git $CONSENSUS_SPEC_TEST_DATA_DIR
 fi
 
 cd $CURRENT_DIR

--- a/vendor/zkllvm-metacraft-circuits/src/circuit_utils/base_types.h
+++ b/vendor/zkllvm-metacraft-circuits/src/circuit_utils/base_types.h
@@ -77,7 +77,9 @@ struct CheckpointVariable {
 
 struct JustificationBitsVariable {
 
-    static_vector<bool, 4, true> bits;
+    static constexpr auto bits_size = 4;
+
+    static_vector<bool, bits_size, true> bits;
 
     constexpr JustificationBitsVariable(const std::array<bool, decltype(bits)::capacity> &init) {
         size_t i = 0;
@@ -87,7 +89,7 @@ struct JustificationBitsVariable {
     }
 
     constexpr JustificationBitsVariable() {
-        for (size_t i = 0; i < bits.size(); ++i) {
+        for (size_t i = 0; i < bits_size; ++i) {
             bits[i] = false;
         }
     }
@@ -109,8 +111,11 @@ struct JustificationBitsVariable {
         assert_in_executable(lower_bound >= 0);
         assert_in_executable(upper_bound_non_inclusive <= bits.size());
         bool result = true;
-        for (size_t i = lower_bound; i < upper_bound_non_inclusive; i++) {
-            result = result && bits[i];
+        for (size_t i = 0; i < bits_size; i++) {
+            auto pos = i + lower_bound;
+            if (pos < upper_bound_non_inclusive) {
+                result = result && bits[pos];
+            }
         }
         return result;
     }

--- a/vendor/zkllvm-metacraft-circuits/src/circuits_impl/compute_shuffled_index_impl.h
+++ b/vendor/zkllvm-metacraft-circuits/src/circuits_impl/compute_shuffled_index_impl.h
@@ -8,18 +8,25 @@
 
 using namespace circuit_byte_utils;
 
+static constexpr uint64_t MAX_SHUFFLE_ROUND_COUNT = 90;
+
 uint64_t compute_shuffled_index_impl(uint64_t index, uint64_t index_count, Bytes32 seed, int shuffle_round_count) {
     assert_true(index < index_count);
+    assert_true(shuffle_round_count <= MAX_SHUFFLE_ROUND_COUNT);
 
     // Swap or not (https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf)
     // See the 'generalized domain' algorithm on page 3
-    for (Byte current_round = 0; current_round < shuffle_round_count; current_round++) {
+    for (Byte current_round = 0; current_round < MAX_SHUFFLE_ROUND_COUNT; current_round++) {
+        // Exit after shuffle_round_count iterations
+        if (current_round == shuffle_round_count) {
+            return index;
+        }
 
-        auto pivot = bytes_to_int<uint64_t>(take<8>(sha256(seed, current_round))) % index_count;
+        auto pivot = bytes_to_int<uint64_t>(take<8>(sha256_33(seed, current_round))) % index_count;
         uint64_t flip = (pivot + index_count - index) % index_count;
         auto position = std::max(index, flip);
 
-        Bytes32 seed_hash = sha256(seed, current_round, int_to_bytes(uint32_t(position / 256)));
+        Bytes32 seed_hash = sha256_37(seed, current_round, int_to_bytes(uint32_t(position / 256)));
         auto byte = seed_hash[(position % 256) / 8];
         auto bit = (byte >> (position % 8)) % 2;
 

--- a/vendor/zkllvm-metacraft-circuits/src/tests/verify_attestation_data_test/verify_attestation_data_test.cpp
+++ b/vendor/zkllvm-metacraft-circuits/src/tests/verify_attestation_data_test/verify_attestation_data_test.cpp
@@ -334,7 +334,7 @@ int main(int argc, char* argv[]) {
 
     {    // process all pubkeys at once
         Transition voted_transition;
-        PubKey* trusted_pubkeys = (PubKey*)malloc(sizeof(PubKey) * 1'000'000);
+        PubKey* trusted_pubkeys = (PubKey*)malloc(sizeof(PubKey) * MAX_PUB_KEYS_TO_PROCESS);
         size_t i = 0;
         size_t unique_keys_count = 0;
         for (auto& keys_set : data["trusted_pubkeys"]) {


### PR DESCRIPTION
Since the latest version 17.0.4 of clang-zkllvm loops need to be bound by compile time constants. This PR introduces the necessary changes in order to follow this rule. 