### PR TITLE
Remove `solana` package

### DIFF
--- a/libs/nix/common-shell-pkgs.nix
+++ b/libs/nix/common-shell-pkgs.nix
@@ -83,7 +83,6 @@ in
     metacraft-labs.rapidsnark
   ]
   ++ lib.optionals (stdenv.isLinux && stdenv.isx86_64) [
-    metacraft-labs.solana
     nim # Compiling Nim 1.6.8 is currently broken on macOS/M1
     nim-wasm
 


### PR DESCRIPTION
We needed to remove Solana from `nix-blockchain-dev` because it wasn't building and was blocking updates there. Now it blocks updates in DendrETH too