### PR TITLE
Introduce the use of path aliases in `@dendreth/relay` 

### DIFF
--- a/beacon-light-client/plonky2/input_fetchers/package.json
+++ b/beacon-light-client/plonky2/input_fetchers/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@types/circomlibjs": "^0",
     "@types/json-bigint": "^1",
+    "@types/node": "^18.0.0",
     "@types/yargs": "^17.0.32",
     "tsx": "^4.7.1"
   },

--- a/beacon-light-client/plonky2/input_fetchers/tsconfig.json
+++ b/beacon-light-client/plonky2/input_fetchers/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../../../tsconfig.json"
+  "extends": "../../../tsconfig.json",
+  "references": [
+    {
+      "path":"../../../relay"
+    }],
 }

--- a/beacon-light-client/solidity/hardhat.config.ts
+++ b/beacon-light-client/solidity/hardhat.config.ts
@@ -1,5 +1,12 @@
 require('dotenv').config();
 
+require('tsconfig-paths').register({
+  baseUrl: './',
+  paths: {
+    '@/*': ['../../relay/*'],
+  },
+});
+
 // Disabled due to compatibility issues with pnpapi
 // TODO: Replace with modern alternative
 // import 'hardhat-gas-reporter';

--- a/beacon-light-client/solidity/package.json
+++ b/beacon-light-client/solidity/package.json
@@ -48,6 +48,7 @@
     "chai-as-promised": "^7.1.2",
     "dotenv": "^16.4.4",
     "env-paths": "^3.0.0",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "5.2.2"
   },
   "exports": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "clean:normal": "yarn clean:jest && EXCL_NM='-e node_modules' yarn clean:untracked_artifacts",
     "clean:jest": "jest --clear-cache",
     "clean:untracked_artifacts": "git clean -fdx -e .env -e .direnv -e .yarn -e .vscode $EXCL_NM -- $(git rev-parse --show-toplevel)",
-    "check:build": "cd beacon-light-client/solidity/ && yarn build:sol && cd ../../ && yarn tsc",
+    "check:build": "cd beacon-light-client/solidity/ && yarn build:sol && cd ../../ && yarn tsc -b ./tsconfig.json",
     "format:check": "prettier --check . && alejandra --exclude ./.yarn --exclude ./node_modules --exclude ./yarn-project.nix --check .",
     "format:write": "prettier --write . && alejandra --exclude ./.yarn --exclude ./node_modules --exclude ./yarn-project.nix .",
     "test": "jest --verbose --silent -i",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,9 @@
     "get-changed-validators": "dist/beacon-light-client/plonky2/validators_commitment_mapper_tree/get_changed_validators.js"
   },
   "dependenciesMeta": {
+    "@lodestar/types@1.17.0": {
+      "unplugged": true
+    },
     "@openzeppelin/contracts@5.0.2": {
       "unplugged": true
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test": "jest --verbose --silent -i",
     "test-emcc": "USE_EMCC=1 jest --verbose --silent",
     "ts": "yarn node --import tsx",
-    "build-plonky-2": "tsc -p beacon-light-client/plonky2/input_fetchers/tsconfig.json"
+    "build-plonky-2": "yarn tsc -b beacon-light-client/plonky2/input_fetchers/tsconfig.json"
   },
   "dependencies": {
     "@chainsafe/bls": "^6.0.3",

--- a/relay/abstraction/beacon-api-interface.ts
+++ b/relay/abstraction/beacon-api-interface.ts
@@ -3,7 +3,7 @@ import {
   ExecutionPayloadHeader,
   SyncAggregate,
   SyncCommittee,
-} from '../types/types';
+} from '@/types/types';
 
 export interface IBeaconApi {
   getBeaconRestApis(): string[];

--- a/relay/abstraction/prover-interface.ts
+++ b/relay/abstraction/prover-interface.ts
@@ -1,4 +1,4 @@
-import { Proof, ProofInputType } from '../types/types';
+import { Proof, ProofInputType } from '@/types/types';
 
 export interface IProver {
   genProof(proofInput: ProofInputType): Promise<Proof>;

--- a/relay/abstraction/redis-interface.ts
+++ b/relay/abstraction/redis-interface.ts
@@ -1,4 +1,4 @@
-import { ProofResultType, WitnessGeneratorInput } from '../types/types';
+import { ProofResultType, WitnessGeneratorInput } from '@/types/types';
 
 export interface IRedis {
   getNextProof(slot: number): Promise<ProofResultType | null>;

--- a/relay/implementations/beacon-api.ts
+++ b/relay/implementations/beacon-api.ts
@@ -1,13 +1,13 @@
 import { UintNumberType, ByteVectorType } from '@chainsafe/ssz';
 import { ValueOfFields } from '@chainsafe/ssz/lib/view/container';
-import { IBeaconApi } from '../abstraction/beacon-api-interface';
+import { IBeaconApi } from '@/abstraction/beacon-api-interface';
 import {
   BeaconBlockHeader,
   ExecutionPayloadHeader,
   SyncAggregate,
   SyncCommittee,
   Validator,
-} from '../types/types';
+} from '@/types/types';
 import { Tree } from '@chainsafe/persistent-merkle-tree';
 import { bytesToHex } from '@dendreth/utils/ts-utils/bls';
 import {

--- a/relay/implementations/cosmos-contract.ts
+++ b/relay/implementations/cosmos-contract.ts
@@ -1,4 +1,4 @@
-import { ISmartContract } from '../abstraction/smart-contract-abstraction';
+import { ISmartContract } from '@/abstraction/smart-contract-abstraction';
 import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { promisify } from 'node:util';

--- a/relay/implementations/eos-contract.ts
+++ b/relay/implementations/eos-contract.ts
@@ -1,4 +1,4 @@
-import { ISmartContract } from '../abstraction/smart-contract-abstraction';
+import { ISmartContract } from '@/abstraction/smart-contract-abstraction';
 import { promisify } from 'node:util';
 import { exec as exec_ } from 'node:child_process';
 import { compileVerifierParseDataTool } from '../../tests/helpers/helpers';

--- a/relay/implementations/eos-contract.ts
+++ b/relay/implementations/eos-contract.ts
@@ -1,8 +1,6 @@
 import { ISmartContract } from '@/abstraction/smart-contract-abstraction';
 import { promisify } from 'node:util';
 import { exec as exec_ } from 'node:child_process';
-import { compileVerifierParseDataTool } from '../../tests/helpers/helpers';
-import { getDataFromPrintHeaderResult } from '@dendreth/utils/cosmos-utils/cosmos-utils';
 import { formatHex } from '@dendreth/utils/ts-utils/bls';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 

--- a/relay/implementations/prover.ts
+++ b/relay/implementations/prover.ts
@@ -1,5 +1,5 @@
-import { IProver } from '../abstraction/prover-interface';
-import { ProofInputType, Proof, WitnessGeneratorInput } from '../types/types';
+import { IProver } from '@/abstraction/prover-interface';
+import { ProofInputType, Proof, WitnessGeneratorInput } from '@/types/types';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 
 const logger = getGenericLogger();

--- a/relay/implementations/redis.ts
+++ b/relay/implementations/redis.ts
@@ -10,7 +10,7 @@ import {
 } from '@/types/types';
 import { RedisClientType, createClient } from 'redis';
 import CONSTANTS from '../../beacon-light-client/plonky2/kv_db_constants.json';
-//
+
 import { Redis as RedisClient, Result } from 'ioredis';
 import chalk from 'chalk';
 import {

--- a/relay/implementations/redis.ts
+++ b/relay/implementations/redis.ts
@@ -1,4 +1,4 @@
-import { IRedis } from '../abstraction/redis-interface';
+import { IRedis } from '@/abstraction/redis-interface';
 import {
   BalanceProof,
   ProofResultType,
@@ -7,7 +7,7 @@ import {
   BlsDepositData,
   BalancesAccumulatorInput,
   CommitmentMapperInput,
-} from '../types/types';
+} from '@/types/types';
 import { RedisClientType, createClient } from 'redis';
 import CONSTANTS from '../../beacon-light-client/plonky2/kv_db_constants.json';
 //
@@ -17,7 +17,7 @@ import {
   getDepthByGindex,
   splitIntoBatches,
 } from '@dendreth/utils/ts-utils/common-utils';
-import { validatorFromValidatorJSON } from '../utils/converters';
+import { validatorFromValidatorJSON } from '@/utils/converters';
 import JSONbig from 'json-bigint';
 
 declare module 'ioredis' {

--- a/relay/implementations/solidity-contract.ts
+++ b/relay/implementations/solidity-contract.ts
@@ -1,11 +1,11 @@
 import { Contract } from 'ethers';
-import { ISmartContract } from '../abstraction/smart-contract-abstraction';
+import { ISmartContract } from '@/abstraction/smart-contract-abstraction';
 import Web3 from 'web3';
 import {
   TransactionSpeed,
   getSolidityProof,
   publishTransaction,
-} from './publish_evm_transaction';
+} from '@/implementations/publish_evm_transaction';
 
 export class SolidityContract implements ISmartContract {
   private lightClientContract: Contract;

--- a/relay/on_chain_publisher.ts
+++ b/relay/on_chain_publisher.ts
@@ -1,19 +1,19 @@
-import { GetUpdate, ProofResultType } from './types/types';
-import { IBeaconApi } from './abstraction/beacon-api-interface';
-import { IRedis } from './abstraction/redis-interface';
-import { ISmartContract } from './abstraction/smart-contract-abstraction';
+import { GetUpdate, ProofResultType } from '@/types/types';
+import { IBeaconApi } from '@/abstraction/beacon-api-interface';
+import { IRedis } from '@/abstraction/redis-interface';
+import { ISmartContract } from '@/abstraction/smart-contract-abstraction';
 import { Contract } from 'ethers';
 import {
   TransactionSpeed,
   getSolidityProof,
   publishTransaction,
-} from './implementations/publish_evm_transaction';
+} from '@/implementations/publish_evm_transaction';
 import Web3 from 'web3';
 import { checkConfig, sleep } from '@dendreth/utils/ts-utils/common-utils';
 import { Queue } from 'bullmq';
-import { Config, UPDATE_POLING_QUEUE } from './constants/constants';
-import { getSlotOnChain } from './utils/smart_contract_utils';
-import { addUpdate } from './utils/orchestrator';
+import { Config, UPDATE_POLING_QUEUE } from '@/constants/constants';
+import { getSlotOnChain } from '@/utils/smart_contract_utils';
+import { addUpdate } from '@/utils/orchestrator';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 
 const logger = getGenericLogger();

--- a/relay/relayer_logger.ts
+++ b/relay/relayer_logger.ts
@@ -3,7 +3,7 @@ import { checkConfig } from '@dendreth/utils/ts-utils/common-utils';
 import {
   PROOF_GENERATOR_QUEUE,
   UPDATE_POLING_QUEUE,
-} from './constants/constants';
+} from '@/constants/constants';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 
 const logger = getGenericLogger();

--- a/relay/save_proof_inputs_from_redis.ts
+++ b/relay/save_proof_inputs_from_redis.ts
@@ -1,5 +1,5 @@
 import { writeFile, writeFileSync } from 'fs';
-import { Redis } from './implementations/redis';
+import { Redis } from '@/implementations/redis';
 
 (async () => {
   const redis = new Redis('localhost', 6379);

--- a/relay/tsconfig.json
+++ b/relay/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
 }

--- a/relay/tsconfig.json
+++ b/relay/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@/lodestar-types": ["../.yarn/unplugged/@lodestar-types-npm-1.17.0-1607a25762/node_modules/@lodestar/types/lib/utils/executionAddress"]
     }
   }
 }

--- a/relay/types/types.ts
+++ b/relay/types/types.ts
@@ -5,7 +5,7 @@ import {
   UintBigintType,
 } from '@chainsafe/ssz';
 import { ValueOfFields } from '@chainsafe/ssz/lib/view/container';
-import { Config } from '../constants/constants';
+import { Config } from '@/constants/constants';
 
 export type BeaconBlockHeader = ValueOfFields<{
   slot: UintNumberType;

--- a/relay/utils/converters.ts
+++ b/relay/utils/converters.ts
@@ -1,5 +1,5 @@
 import { hexToBytes } from '@dendreth/utils/ts-utils/bls';
-import { Validator } from '../types/types';
+import { Validator } from '@/types/types';
 
 function stringToNumber(str: string): number {
   return str == BigInt(2n ** 64n - 1n).toString() ? Infinity : Number(str);

--- a/relay/utils/discord_monitor.ts
+++ b/relay/utils/discord_monitor.ts
@@ -1,8 +1,5 @@
-import { SolidityContract } from '@dendreth/relay/implementations/solidity-contract';
-import {
-  getBeaconApi,
-  BeaconApi,
-} from '@dendreth/relay/implementations/beacon-api';
+import { SolidityContract } from '@/implementations/solidity-contract';
+import { getBeaconApi, BeaconApi } from '@/implementations/beacon-api';
 import { ethers } from 'ethers';
 import { sleep } from '@dendreth/utils/ts-utils/common-utils';
 import { GatewayIntentBits, Events, Partials } from 'discord.js';

--- a/relay/utils/get_current_network_config.ts
+++ b/relay/utils/get_current_network_config.ts
@@ -1,6 +1,6 @@
 import { checkConfig } from '@dendreth/utils/ts-utils/common-utils';
-import { Config } from '../constants/constants';
-import * as network_config from '../constants/network_config.json';
+import { Config } from '@/constants/constants';
+import * as network_config from '@/constants/network_config.json';
 
 export function getNetworkConfig(network: 'pratter' | 'mainnet'): Config {
   const config = {

--- a/relay/utils/orchestrator.ts
+++ b/relay/utils/orchestrator.ts
@@ -1,12 +1,12 @@
 import { Queue } from 'bullmq';
-import { GetUpdate } from '../types/types';
-import { Config } from '../constants/constants';
+import { GetUpdate } from '@/types/types';
+import { Config } from '@/constants/constants';
 import {
   SLOTS_PER_PERIOD,
   computeSyncCommitteePeriodAt,
 } from '@dendreth/utils/ts-utils/ssz-utils';
-import { IBeaconApi } from '../abstraction/beacon-api-interface';
-import { findClosestValidBlock } from '../workers/poll-updates/get_light_client_input_from_to';
+import { IBeaconApi } from '@/abstraction/beacon-api-interface';
+import { findClosestValidBlock } from '@/workers/poll-updates/get_light_client_input_from_to';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 
 const logger = getGenericLogger();

--- a/relay/utils/smart_contract_utils.ts
+++ b/relay/utils/smart_contract_utils.ts
@@ -1,5 +1,5 @@
-import { IBeaconApi } from '../abstraction/beacon-api-interface';
-import { ISmartContract } from '../abstraction/smart-contract-abstraction';
+import { IBeaconApi } from '@/abstraction/beacon-api-interface';
+import { ISmartContract } from '@/abstraction/smart-contract-abstraction';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 
 const logger = getGenericLogger();

--- a/relay/workers/cleaner.ts
+++ b/relay/workers/cleaner.ts
@@ -1,8 +1,8 @@
 import { Queue } from 'bullmq';
 import { checkConfig, sleep } from '@dendreth/utils/ts-utils/common-utils';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
-import { GetUpdate } from '../types/types';
-import { UPDATE_POLING_QUEUE } from '../constants/constants';
+import { GetUpdate } from '@/types/types';
+import { UPDATE_POLING_QUEUE } from '@/constants/constants';
 
 const logger = getGenericLogger();
 

--- a/relay/workers/poll-updates/do_update.ts
+++ b/relay/workers/poll-updates/do_update.ts
@@ -1,8 +1,8 @@
 import { Queue } from 'bullmq';
-import { IBeaconApi } from '../../abstraction/beacon-api-interface';
-import { getInputFromTo } from './get_light_client_input_from_to';
-import { ProofInputType } from '../../types/types';
-import { Config } from '../../constants/constants';
+import { IBeaconApi } from '@/abstraction/beacon-api-interface';
+import { getInputFromTo } from '@/workers/poll-updates/get_light_client_input_from_to';
+import { ProofInputType } from '@/types/types';
+import { Config } from '@/constants/constants';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 
 const logger = getGenericLogger();

--- a/relay/workers/poll-updates/get_light_client_input_from_to.ts
+++ b/relay/workers/poll-updates/get_light_client_input_from_to.ts
@@ -1,7 +1,7 @@
-import { Config } from '../../constants/constants';
-import { getProofInput } from './get_ligth_client_input';
-import { IBeaconApi } from '../../abstraction/beacon-api-interface';
-import { BeaconBlockHeader, SyncAggregate } from '../../types/types';
+import { Config } from '@/constants/constants';
+import { getProofInput } from '@/workers/poll-updates/get_ligth_client_input';
+import { IBeaconApi } from '@/abstraction/beacon-api-interface';
+import { BeaconBlockHeader, SyncAggregate } from '@/types/types';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 import { prometheusTiming } from '@dendreth/utils/ts-utils/prometheus-utils';
 

--- a/relay/workers/poll-updates/get_ligth_client_input.ts
+++ b/relay/workers/poll-updates/get_ligth_client_input.ts
@@ -14,14 +14,14 @@ import {
   formatHex,
 } from '@dendreth/utils/ts-utils/bls';
 import { Tree } from '@chainsafe/persistent-merkle-tree';
-import { Config } from '../../constants/constants';
+import { Config } from '@/constants/constants';
 import {
   BeaconBlockHeader,
   ExecutionPayloadHeader,
   SyncAggregate,
   SyncCommittee,
   WitnessGeneratorInput,
-} from '../../types/types';
+} from '@/types/types';
 import { computeSyncCommitteePeriodAt } from '@dendreth/utils/ts-utils/ssz-utils';
 
 const ExecutionPayload = new ContainerType({

--- a/relay/workers/poll-updates/poll-updates-worker.ts
+++ b/relay/workers/poll-updates/poll-updates-worker.ts
@@ -1,12 +1,12 @@
 import { Worker, Queue } from 'bullmq';
 import { exec as _exec } from 'child_process';
-import { GetUpdate, ProofInputType } from '../../types/types';
+import { GetUpdate, ProofInputType } from '@/types/types';
 import {
   PROOF_GENERATOR_QUEUE,
   UPDATE_POLING_QUEUE,
-} from '../../constants/constants';
-import doUpdate from './do_update';
-import { getBeaconApi } from '@dendreth/relay/implementations/beacon-api';
+} from '@/constants/constants';
+import doUpdate from '@/workers/poll-updates/do_update';
+import { getBeaconApi } from '@/implementations/beacon-api';
 import { checkConfig } from '@dendreth/utils/ts-utils/common-utils';
 import { getGenericLogger } from '@dendreth/utils/ts-utils/logger';
 import { initPrometheusSetup } from '@dendreth/utils/ts-utils/prometheus-utils';

--- a/relay/workers/prover/gen_proof.ts
+++ b/relay/workers/prover/gen_proof.ts
@@ -1,6 +1,6 @@
-import { IProver } from '../../abstraction/prover-interface';
-import { IRedis } from '../../abstraction/redis-interface';
-import { ProofInputType } from '../../types/types';
+import { IProver } from '@/abstraction/prover-interface';
+import { IRedis } from '@/abstraction/redis-interface';
+import { ProofInputType } from '@/types/types';
 
 export default async function genProof(
   redis: IRedis,

--- a/relay/workers/prover/prover-worker.ts
+++ b/relay/workers/prover/prover-worker.ts
@@ -1,10 +1,10 @@
 import { Worker } from 'bullmq';
 import { exec as _exec } from 'child_process';
-import { ProofInputType } from '../../types/types';
-import genProof from './gen_proof';
-import { Redis } from '@dendreth/relay/implementations/redis';
-import { Prover } from '@dendreth/relay/implementations/prover';
-import { PROOF_GENERATOR_QUEUE } from '../../constants/constants';
+import { ProofInputType } from '@/types/types';
+import genProof from '@/workers/prover/gen_proof';
+import { Redis } from '@/implementations/redis';
+import { Prover } from '@/implementations/prover';
+import { PROOF_GENERATOR_QUEUE } from '@/constants/constants';
 import { checkConfig } from '@dendreth/utils/ts-utils/common-utils';
 import yargs from 'yargs';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -96,7 +96,8 @@
   },
   "exclude": [
     "node_modules",
-    "vendor"
+    "vendor",
+    "dist",
   ],
   "references": [
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,5 +102,8 @@
     {
       "path":"./relay"
     }],
-  "include": ["**/*.ts"]
+  "files": ["vendor/eth2-light-client-updates/mainnet/bootstrap.json",
+            "vendor/eth2-light-client-updates/mainnet/updates/00290.json",
+            "vendor/eth2-light-client-updates/prater/capella-updates-94/update_5601823_5609044.json"],
+  "include": ["**/*.ts", "**/*.json"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
     // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
@@ -24,7 +24,7 @@
     /* Modules */
     "module": "ESNext",                                  /* Specify what module code is generated. */
     "moduleResolution": "Bundler",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -41,8 +41,8 @@
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
@@ -96,6 +96,11 @@
   },
   "exclude": [
     "node_modules",
-    "vendor",
-  ]
+    "vendor"
+  ],
+  "references": [
+    {
+      "path":"./relay"
+    }],
+  "include": ["**/*.ts"]
 }

--- a/yarn-project.nix
+++ b/yarn-project.nix
@@ -52,7 +52,7 @@ let
       rm $out/.gitignore
     '';
     outputHashMode = "recursive";
-    outputHash = "sha512-8jmYm01fpJ6mAmJjdI4q8rXx/jNlyNjRj62R2X28yw+HgxXs/QdhMnFaFYvzbkYQicMHEEJvXUkEvIgf6trkRQ==";
+    outputHash = "sha512-XnZrzm0RE8x/CgIUUmGGlw9H8QV6UfeVj/+GJ5+/QGZ0cE/b3TgjQJRqQY4fAPd6fT4CUi5KGh1v3jmSQ0TaPQ==";
   };
 
   # Create a derivation that builds a module in isolation.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5204,6 +5204,8 @@ __metadata:
     winston: "npm:^3.10.0"
     yargs: "npm:^17.7.2"
   dependenciesMeta:
+    "@lodestar/types@1.17.0":
+      unplugged: true
     "@openzeppelin/contracts@5.0.2":
       unplugged: true
     circomlib@2.0.2:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,6 +1684,7 @@ __metadata:
     r1csfile: "npm:^0.0.40"
     snarkjs: "https://github.com/metacraft-labs/snarkjs.git#commit=091ee9c3744c660b0ecd961f9197a8249a8f7d3b"
     ts-node: "npm:^10.9.1"
+    tsconfig-paths: "npm:^4.2.0"
     typescript: "npm:5.2.2"
     web3: "npm:1.10.4"
   languageName: unknown
@@ -10765,7 +10766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.1, json5@npm:^2.2.3":
+"json5@npm:^2.1.1, json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -14222,6 +14223,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-bom@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-bom@npm:3.0.0"
+  checksum: 10/8d50ff27b7ebe5ecc78f1fe1e00fcdff7af014e73cf724b46fb81ef889eeb1015fc5184b64e81a2efe002180f3ba431bdd77e300da5c6685d702780fbf0c8d5b
+  languageName: node
+  linkType: hard
+
 "strip-bom@npm:^4.0.0":
   version: 4.0.0
   resolution: "strip-bom@npm:4.0.0"
@@ -14647,6 +14655,17 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 10/a91a15b3c9f76ac462f006fa88b6bfa528130dcfb849dd7ef7f9d640832ab681e235b8a2bc58ecde42f72851cc1d5d4e22c901b0c11aa51001ea1d395074b794
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "tsconfig-paths@npm:4.2.0"
+  dependencies:
+    json5: "npm:^2.2.2"
+    minimist: "npm:^1.2.6"
+    strip-bom: "npm:^3.0.0"
+  checksum: 10/5e55cc2fb6b800eb72011522e10edefccb45b1f9af055681a51354c9b597d1390c6fa9cc356b8c7529f195ac8a90a78190d563159f3a1eed10e01bbd4d01a8ab
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,6 +1598,7 @@ __metadata:
     "@noble/bls12-381": "npm:^1.4.0"
     "@types/circomlibjs": "npm:^0"
     "@types/json-bigint": "npm:^1"
+    "@types/node": "npm:^18.0.0"
     "@types/yargs": "npm:^17.0.32"
     chalk: "npm:^4.1.2"
     circom-pairing: "link:../../../vendor/circom-pairing/"


### PR DESCRIPTION
### This PR introduces the use of path aliases and sets up the project to support them.

While this change might seem like a simple refactor, it uncovered numerous issues with the overall configuration of the monorepo. Debugging and resolving these problems involved running our build scripts: `yarn check:build` and `yarn build-plonky-2`.

#### Here is a list of problems encountered and the fixes implemented:

- refactor(relay): Use @ for paths within /relay

- build(@dendreth/solidity): Install `tsconfig-paths`

- config(@dendreth/solidity): Update `hardhat.config.ts` to use `tsconfig-paths`

  Hardhat does not natively support TypeScript path aliases out of the box.
  However, we can use `tsconfig-paths` package to achieve this.

  With this we fix errors like this:

  ```
  An unexpected error occurred:

  Error: Your application tried to access @, but it isn't declared in your dependencies;
  this makes the require call ambiguous and unsound.

  Required package: @ (via "@/constants/network_config.json")
  Required by: <path>/DendrETH/relay/utils/
  ```

- build(check:build): Refactor script to run `tsc` with `--build` flag

  The `--build` option can be seen as a build orchestrator that find referenced
  projects, check if they are up-to-date, and build out-of-date projects in the
  correct order.

  The path aliases changes we want to introduce, forces the need of referenced
  projects.

- config(tsconfig.json): Streamline the configuration to work with path aliases

  `compilerOptions` updates:

  - "composite": true
  - "rootDir": "./"
  - "declaration": true
  - "declarationMap": true

  Add `references` to the `relay` workspace
  Make sure all ts files are included

- config(tsconfig.json): Make sure all `json` files are included

  This change resolves problems like this:

  ```
  error TS6307: File '<path>/DendrETH/beacon-light-client/plonky2/input_fetchers/balance_verification/abi/lido_accounting_oracle_abi.json' is not listed within the file list of project '<path>DendrETH/relay/tsconfig.json'. Projects must list all files or use an 'include' pattern.

  7 import accountingOracleAbi from '../../abi/lido_accounting_oracle_abi.json';
  ```

- build(yarn): Unplug `@lodestar/types@1.17.0`

- config(relay): Add `@lodestar/types` in paths.

    This change fixes following problems:

      ```
      relay/implementations/beacon-api.ts:543:9 - error TS2742: The inferred type of 'getBeaconBlock' cannot be named without a reference to '../../.yarn/unplugged/@lodestar-types-npm-1.17.0-1607a25762/node_modules/@lodestar/types/lib/u tils/executionAddress'. This is likely not portable. A type annotation is necessary.

      543   async getBeaconBlock(slot: bigint) {
                  ~~~~~~~~~~~~~~

      relay/implementations/beacon-api.ts:574:9 - error TS2742: The inferred type of 'getBeaconState' cannot be named without a reference to '../../.yarn/unplugged/@lodestar-types-npm-1.17.0-1607a25762/node_modules/@lodestar/types/lib/utils/executionAddress'. This is likely not portable. A type annotation is necessary.

      574   async getBeaconState(slot: bigint) {
                  ~~~~~~~~~~~~~~

      Found 2 errors.
      ```

- config(tsconfig.json): Exclude `dist` dir

  This fixes problems like:

  ```
  error TS5055: Cannot write file <file-path> because it would overwrite input file.
  ```

- build(build-plonky-2): Refactor script to use `--build` flag

- config(@dendreth/balance-verification): Add project references

    The `@dendreth/balance-verification` workspace rely on files from `@dendreth/relay`.
    That is why we need to add this reference.

    With this change following proble was resolved:
    Running `yarn build-plonky-2` ends in:

      ```
      error TS2688: Cannot find type definition file for 'node'.
        The file is in the program because:
          Entry point of type library 'node' specified in compilerOptions

      relay/implementations/beacon-api.ts:543:9 - error TS2742: The inferred type of 'getBeaconBlock' cannot be named without a reference to '../../.yarn/unplugged/@lodestar-types-npm-1.17.0-1607a25762/node_modules/@lodestar/types/lib/utils/executionAddress'. This is likely not portable. A type annotation is necessary.

      543   async getBeaconBlock(slot: bigint) {
                  ~~~~~~~~~~~~~~

      relay/implementations/beacon-api.ts:574:9 - error TS2742: The inferred type of 'getBeaconState' cannot be named without a reference to '../../.yarn/unplugged/@lodestar-types-npm-1.17.0-1607a25762/node_modules/@lodestar/types/lib/utils/executionAddress'. This is likely not portable. A type annotation is necessary.

      574   async getBeaconState(slot: bigint) {
                  ~~~~~~~~~~~~~~

      Found 3 errors in the same file, starting at: relay/implementations/beacon-api.ts:543
      ```

- build(@dendreth/balance-verification): Add `@types/node`

- refactor(relay): Remove unused imports
