### PR TITLE
ci: migrate CI to self-hosted eph-* runners

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: eph-linux-x64
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Migrate GitHub-hosted CI runners to Metacraft Labs self-hosted eph-* classes, per org policy (all CI must run on self-hosted eph-* runner classes).

## Substitution
- `.github/workflows/update-flake-lock.yml:13`: `runs-on: ubuntu-latest` -> `runs-on: eph-linux-x64`

All jobs in `ci.yml` already use `self-hosted` runners and were left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)